### PR TITLE
Make compile and add Go module support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/tsdgeos/nopullrequests
+
+go 1.13
+
+require (
+	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/go-querystring v1.0.0 // indirect
+	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
+	google.golang.org/appengine v1.6.5
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
+github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
+google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=

--- a/nopr.go
+++ b/nopr.go
@@ -97,7 +97,7 @@ func oauthHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ghu, _, err := newClient(ctx, tok).Users.Get("")
+	ghu, _, err := newClient(ctx, tok).Users.Get(ctx, "")
 	if err != nil {
 		log.Errorf(ctx, "getting user: %v", err)
 		renderError(w, "Error getting user")
@@ -121,6 +121,10 @@ func getAccessToken(ctx context.Context, code string) (string, error) {
 	url := fmt.Sprintf("https://github.com/login/oauth/access_token?client_id=%s&client_secret=%s&code=%s",
 		clientID, clientSecret, code)
 	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		log.Errorf(ctx, "posting request: %v", err)
+		return "", err
+	}
 	req.Header.Set("Accept", "application/json")
 	resp, err := client.Do(req)
 	if err != nil {
@@ -154,7 +158,7 @@ func (t transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 type User struct {
 	GoogleUserID string
-	GitHubUserID int
+	GitHubUserID int64
 	GitHubToken  string
 }
 
@@ -196,7 +200,7 @@ func userHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	allRepos := []github.Repository{}
+	allRepos := []*github.Repository{}
 	opt := &github.RepositoryListOptions{
 		Type: "admin",
 		ListOptions: github.ListOptions{
@@ -204,7 +208,7 @@ func userHandler(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 	for {
-		repos, resp, err := newClient(ctx, u.GitHubToken).Repositories.List("", opt)
+		repos, resp, err := newClient(ctx, u.GitHubToken).Repositories.List(ctx, "", opt)
 		if err != nil {
 			log.Errorf(ctx, "listing repos: %v", err)
 			renderError(w, "Error listing repos")
@@ -218,7 +222,7 @@ func userHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	type data struct {
-		Repo     github.Repository
+		Repo     *github.Repository
 		Disabled bool
 	}
 	d := []data{}
@@ -254,7 +258,7 @@ func userHandler(w http.ResponseWriter, r *http.Request) {
 type Repo struct {
 	FullName  string // e.g., MyUser/foo-bar
 	UserID    string // User key to use to close PRs
-	WebhookID int    // Used to delete the hook
+	WebhookID int64  // Used to delete the hook
 }
 
 func (r Repo) Split() (string, string) {
@@ -311,7 +315,7 @@ func disableHandler(w http.ResponseWriter, r *http.Request) {
 	fullName := r.URL.Path[len("/disable/"):]
 
 	ghUser, ghRepo := Repo{FullName: fullName}.Split()
-	hook, _, err := newClient(ctx, u.GitHubToken).Repositories.CreateHook(ghUser, ghRepo, &github.Hook{
+	hook, _, err := newClient(ctx, u.GitHubToken).Repositories.CreateHook(ctx, ghUser, ghRepo, &github.Hook{
 		Name:   github.String("web"),
 		Events: []string{"pull_request"},
 		Config: map[string]interface{}{
@@ -367,7 +371,7 @@ func enableHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ghUser, ghRepo := repo.Split()
-	if _, err := newClient(ctx, u.GitHubToken).Repositories.DeleteHook(ghUser, ghRepo, repo.WebhookID); err != nil {
+	if _, err := newClient(ctx, u.GitHubToken).Repositories.DeleteHook(ctx, ghUser, ghRepo, repo.WebhookID); err != nil {
 		log.Errorf(ctx, "delete hook: %v", err)
 		renderError(w, "Error deleting webhook")
 		return
@@ -432,7 +436,7 @@ func webhookHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	*/
 
-	if _, _, err := client.Issues.CreateComment(ghUser, ghRepo, *hook.Number, &github.IssueComment{
+	if _, _, err := client.Issues.CreateComment(ctx, ghUser, ghRepo, *hook.Number, &github.IssueComment{
 		Body: github.String(`
 Thanks for your contribution :smiley:
 
@@ -442,7 +446,7 @@ Please see https://community.kde.org/Infrastructure/Github_Mirror for details on
 		log.Errorf(ctx, "failed to create comment: %v", err)
 	}
 
-	if _, _, err := client.PullRequests.Edit(ghUser, ghRepo, *hook.Number, &github.PullRequest{
+	if _, _, err := client.PullRequests.Edit(ctx, ghUser, ghRepo, *hook.Number, &github.PullRequest{
 		State: github.String("closed"),
 	}); err != nil {
 		log.Errorf(ctx, "failed to close pull request: %v", err)
@@ -482,7 +486,7 @@ func revokeHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		ghUser, ghRepo := r.Split()
-		if _, err := client.Repositories.DeleteHook(ghUser, ghRepo, r.WebhookID); err != nil {
+		if _, err := client.Repositories.DeleteHook(ctx, ghUser, ghRepo, r.WebhookID); err != nil {
 			log.Errorf(ctx, "delete hook: %v", err)
 			renderError(w, "Error deleting hook")
 			return


### PR DESCRIPTION
Fixes compilation and adds support for Go modules, which pins the dependencies to a specific version, so we don't run into these issues again that quickly.