### PR TITLE
Use Go 1.11 runtime so that appengine stuff works

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: go112
+runtime: go111
 
 handlers:
 - url: /static


### PR DESCRIPTION
Go 1.12 does not support google.golang.org/appengine and other packages
under it.